### PR TITLE
Added 'UnixLike' OS type.

### DIFF
--- a/rubrikinc/cdm/docs/rubrik_assign_physical_host_fileset.md
+++ b/rubrikinc/cdm/docs/rubrik_assign_physical_host_fileset.md
@@ -1,6 +1,6 @@
 # rubrik_assign_physical_host_fileset   
 
-Assign a fileset to a Linux or Windows machine. If you have multiple filesets with identical names, you will need to populate the filesets properties to find a specific match. Filesets with identical names and properties are not supported.
+Assign a fileset to a Linux, Unix or Windows machine. If you have multiple filesets with identical names, you will need to populate the filesets properties to find a specific match. Filesets with identical names and properties are not supported.
 
 `Requirement: Rubrik Python SDK (pip install rubrik_cdm)`
 
@@ -36,11 +36,11 @@ Assign a fileset to a Linux or Windows machine. If you have multiple filesets wi
 | backup_hidden_folders | Include or exclude hidden folders inside locally-mounted remote file systems from backups.                   | False   | Bool   |                |           |            |
 | exclude               | The full paths or wildcards that define the objects to exclude from the Fileset backup.                      | []      | list   |                |           |            |
 | exclude_exception     | The full paths or wildcards that define the objects that are exempt from the excludes variables.             | []      | list   |                |           |            |
-| fileset_name          | The name of the Fileset you wish to assign to the Linux or Windows host.                                     |         | string |                | true      |            |
+| fileset_name          | The name of the Fileset you wish to assign to the Linux, Unix or Windows host.                                     |         | string |                | true      |            |
 | follow_network_shares | Include or exclude locally-mounted remote file systems from backups.                                         | False   | bool   |                |           |            |
 | hostname              | The hostname or IP Address of the physical host you wish to associate to the Fileset.                        |         | string |                | true      | ip_address |
 | include               | The full paths or wildcards that define the objects to include in the Fileset backup.                        | []      | list   |                |           |            |
-| operating_system      | The operating system of the physical host you are assigning a Fileset to                                     |         | string | Linux, Windows | true      |            |
+| operating_system      | The operating system of the physical host you are assigning a Fileset to                                     |         | string | Linux, Windows, UnixLike | true      |            |
 | sla_name              | The name of the SLA Domain to associate with the Fileset.                                                    |         | string |                |           | sla        |
 | timeout               | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. | 30      | int    |                |           |            |
 

--- a/rubrikinc/cdm/plugins/modules/rubrik_assign_physical_host_fileset.py
+++ b/rubrikinc/cdm/plugins/modules/rubrik_assign_physical_host_fileset.py
@@ -42,7 +42,7 @@ options:
     description:
       - The operating system of the physical host you are assigning a Fileset to.
     required: true
-    choices: ['Linux', 'Windows']
+    choices: ['Linux', 'Windows', 'UnixLike']
     type: str
   include:
     description:
@@ -149,7 +149,7 @@ def main():
             hostname=dict(required=True, type='str', aliases=['ip_address']),
             fileset_name=dict(required=True, type='str'),
             sla_name=dict(required=True, type='str', aliases=['sla']),
-            operating_system=dict(required=True, type='str', choices=['Linux', 'Windows']),
+            operating_system=dict(required=True, type='str', choices=['Linux', 'Windows', 'UnixLike']),
             include=dict(required=False, type='list', default=[]),
             exclude=dict(required=False, type='list', default=[]),
             exclude_exception=dict(required=False, type='list', default=[]),

--- a/rubrikinc/cdm/plugins/modules/rubrik_assign_physical_host_fileset.py
+++ b/rubrikinc/cdm/plugins/modules/rubrik_assign_physical_host_fileset.py
@@ -14,9 +14,9 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = '''
 module: rubrik_assign_physical_host_fileset
-short_description: Assign a Rubrik fileset to a Linux or Windows machine.
+short_description: Assign a Rubrik fileset to a Linux, Unix or Windows machine.
 description:
-    - Assign a fileset to a Linux or Windows machine. If you have multiple filesets with identical names, you will
+    - Assign a fileset to a Linux, Unix or Windows machine. If you have multiple filesets with identical names, you will
       need to populate the filesets properties to find a specific match. Filesets with identical names and properties are not supported.
 version_added: '2.8'
 author: Rubrik Build Team (@drew-russell) <build@rubrik.com>
@@ -29,7 +29,7 @@ options:
     type: str
   fileset_name:
     description:
-      - The name of the Fileset you wish to assign to the Linux or Windows host.
+      - The name of the Fileset you wish to assign to the Linux, Unix or Windows host.
     required: true
     type: str
   sla_name:


### PR DESCRIPTION
# Description

Added 'UnixLike' OS type to be able to assign filesets to AIX and other Unix hosts.

## Motivation and Context

Currently, we are unable to assign filesets to Unix (AIX, for example) hosts.

## How Has This Been Tested?

In my lab by assigning a fileset to an AIX host.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
