### PR TITLE
Fix CircleCi Testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 version: 2.0
 
 jobs:
-
- python-2.7:
+  python-2.7:
     docker:
       - image: circleci/python:2.7.16
     working_directory: ~/rubrik-modules-for-ansible
@@ -33,8 +32,8 @@ jobs:
           command: |
             cd ~/.ansible/collections/ansible_collections/rubrikinc/cdm
             ~/ansible/bin/ansible-test sanity --test compile --python 2.7
- 
- python-3.5:
+
+  python-3.5:
     docker:
       - image: circleci/python:3.5.7
         environment:
@@ -72,9 +71,11 @@ jobs:
             sudo pip install ansible --progress-bar off
             pytest ~/.ansible/collections/ansible_collections/rubrikinc/cdm/tests/unit
 
- python-3.6:
+  python-3.6:
     docker:
       - image: circleci/python:3.6.9
+        environment:
+          PYTHONPATH: /home/circleci/.ansible/collections
     working_directory: ~/rubrik-modules-for-ansible
     environment:
       ANSIBLE_COLLECTIONS_PATHS: ~/.ansible/collections
@@ -106,10 +107,12 @@ jobs:
           command: |
             sudo pip install ansible --progress-bar off
             pytest ~/.ansible/collections/ansible_collections/rubrikinc/cdm/tests/unit
- 
- python-3.7:
+
+  python-3.7:
     docker:
       - image: circleci/python:3.7.4
+        environment:
+          PYTHONPATH: /home/circleci/.ansible/collections
     working_directory: ~/rubrik-modules-for-ansible
     environment:
       ANSIBLE_COLLECTIONS_PATHS: ~/.ansible/collections
@@ -142,9 +145,11 @@ jobs:
             sudo pip install ansible --progress-bar off
             pytest ~/.ansible/collections/ansible_collections/rubrikinc/cdm/tests/unit
 
- python-3.8:
+  python-3.8:
     docker:
       - image: circleci/python:3.8.0b4
+        environment:
+          PYTHONPATH: /home/circleci/.ansible/collections
     working_directory: ~/rubrik-modules-for-ansible
     environment:
       ANSIBLE_COLLECTIONS_PATHS: ~/.ansible/collections
@@ -186,5 +191,3 @@ workflows:
       - python-3.6
       - python-3.7
       #- python-3.8
-
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,20 +20,26 @@ jobs:
           command: |
             git clone https://github.com/ansible/ansible.git ~/ansible
             source ~/ansible/hacking/env-setup
-            mkdir -p ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
-            cp -a ~/rubrik-modules-for-ansible/rubrikinc/cdm/. ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/rubrik_module_template.py
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/create_documentation_block.py
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/quick-start.md
+            mkdir -p ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            cp -a ~/rubrik-modules-for-ansible/rubrikinc/cdm/. ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            ls ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            rm -f ~/.ansible/collections/ansible_collections/rubrikinc/cdm/docs/template.md
+            rm -f ~/.ansible/collections/ansible_collections/rubrikinc/cdm/docs/create_documentation_block.py
+            rm -f ~/.ansible/collections/ansible_collections/rubrikinc/cdm/docs/rubrik_module_template.py
+            rm -f ~/.ansible/collections/ansible_collections/rubrikinc/cdm/docs/README.md
+            rm -f ~/.ansible/collections/ansible_collections/rubrikinc/cdm/docs/SUMMARY.md
       - run:
           name: Execute Ansible Sanity Test
           command: |
-            cd ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
+            cd ~/.ansible/collections/ansible_collections/rubrikinc/cdm
             ~/ansible/bin/ansible-test sanity --test compile --python 2.7
  
  python-3.5:
     docker:
       - image: circleci/python:3.5.7
+        environment:
+          PYTHONPATH: /home/circleci/.ansible/collections
+
     working_directory: ~/rubrik-modules-for-ansible
     environment:
       ANSIBLE_COLLECTIONS_PATHS: ~/.ansible/collections
@@ -42,32 +48,29 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            sudo pip install pylint requests python-dateutil pytz coverage pytest-cov pytest-mock tox pep8 autopep8 rubrik_cdm paramiko PyYAML Jinja2 httplib2 six voluptuous isort lazy-object-proxy wrapt docutils rstcheck pathspec yamllint
+            sudo pip install pylint requests python-dateutil pytz coverage pytest-cov pytest-mock tox pep8 autopep8 rubrik_cdm paramiko PyYAML Jinja2 httplib2 six voluptuous isort lazy-object-proxy wrapt docutils rstcheck pathspec yamllint --progress-bar off
             sudo apt-get install -y man
       - run:
           name: Clone and Setup Ansible Dev Tools
           command: |
             git clone https://github.com/ansible/ansible.git ~/ansible
             source ~/ansible/hacking/env-setup
-            mkdir -p ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
-            cp -a ~/rubrik-modules-for-ansible/rubrikinc/cdm/. ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/rubrik_module_template.py
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/create_documentation_block.py
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/quick-start.md
+            mkdir -p ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            chown -R $USER:$USER ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            cp -a ~/rubrik-modules-for-ansible/rubrikinc/cdm/. ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            rm -f ~/.ansible/collections/ansible_collections/rubrikinc/cdm/docs/{template.md,create_documentation_block.py,create_documentation_block.py,rubrik_module_template.py,README.md,SUMMARY.md}
+            python collection_dev.py --action update_path --platform circleci
+
       - run:
           name: Execute Ansible Sanity Test
           command: |
-            cd ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
+            cd ~/.ansible/collections/ansible_collections/rubrikinc/cdm
             ~/ansible/bin/ansible-test sanity --skip-test shebang
       - run:
           name: Execute Unit Tests
           command: |
             sudo pip install ansible --progress-bar off
-            cd ~/.ansible/collections
-            ln -s ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/plugins/ plugins
-            ln -s ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm ./ansible_collections/rubrikinc
-            ln -s ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/plugins/module_utils/ ./ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/module_utils
-            python -m unittest discover -s ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/tests/unit
+            pytest ~/.ansible/collections/ansible_collections/rubrikinc/cdm/tests/unit
 
  python-3.6:
     docker:
@@ -80,32 +83,29 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            sudo pip install pylint requests python-dateutil pytz coverage pytest-cov pytest-mock tox pep8 autopep8 rubrik_cdm paramiko PyYAML Jinja2 httplib2 six voluptuous isort lazy-object-proxy wrapt docutils rstcheck pathspec yamllint
+            sudo pip install pylint requests python-dateutil pytz coverage pytest-cov pytest-mock tox pep8 autopep8 rubrik_cdm paramiko PyYAML Jinja2 httplib2 six voluptuous isort lazy-object-proxy wrapt docutils rstcheck pathspec yamllint --progress-bar off
             sudo apt-get install -y man
       - run:
           name: Clone and Setup Ansible Dev Tools
           command: |
             git clone https://github.com/ansible/ansible.git ~/ansible
             source ~/ansible/hacking/env-setup
-            mkdir -p ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
-            cp -a ~/rubrik-modules-for-ansible/rubrikinc/cdm/. ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/rubrik_module_template.py
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/create_documentation_block.py
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/quick-start.md
+            mkdir -p ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            chown -R $USER:$USER ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            cp -a ~/rubrik-modules-for-ansible/rubrikinc/cdm/. ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            rm -f ~/.ansible/collections/ansible_collections/rubrikinc/cdm/docs/{template.md,create_documentation_block.py,create_documentation_block.py,rubrik_module_template.py,README.md,SUMMARY.md}
+            python collection_dev.py --action update_path --platform circleci
+
       - run:
           name: Execute Ansible Sanity Test
           command: |
-            cd ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
+            cd ~/.ansible/collections/ansible_collections/rubrikinc/cdm
             ~/ansible/bin/ansible-test sanity --skip-test shebang
       - run:
           name: Execute Unit Tests
           command: |
             sudo pip install ansible --progress-bar off
-            cd ~/.ansible/collections
-            ln -s ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/plugins/ plugins
-            ln -s ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm ./ansible_collections/rubrikinc
-            ln -s ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/plugins/module_utils/ ./ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/module_utils
-            python -m unittest discover -s ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/tests/unit
+            pytest ~/.ansible/collections/ansible_collections/rubrikinc/cdm/tests/unit
  
  python-3.7:
     docker:
@@ -118,32 +118,29 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            sudo pip install pylint requests python-dateutil pytz coverage pytest-cov pytest-mock tox pep8 autopep8 rubrik_cdm paramiko PyYAML Jinja2 httplib2 six voluptuous isort lazy-object-proxy wrapt docutils rstcheck pathspec yamllint
+            sudo pip install pylint requests python-dateutil pytz coverage pytest-cov pytest-mock tox pep8 autopep8 rubrik_cdm paramiko PyYAML Jinja2 httplib2 six voluptuous isort lazy-object-proxy wrapt docutils rstcheck pathspec yamllint --progress-bar off
             sudo apt-get install -y man
       - run:
           name: Clone and Setup Ansible Dev Tools
           command: |
             git clone https://github.com/ansible/ansible.git ~/ansible
             source ~/ansible/hacking/env-setup
-            mkdir -p ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
-            cp -a ~/rubrik-modules-for-ansible/rubrikinc/cdm/. ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/rubrik_module_template.py
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/create_documentation_block.py
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/quick-start.md
+            mkdir -p ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            chown -R $USER:$USER ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            cp -a ~/rubrik-modules-for-ansible/rubrikinc/cdm/. ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            rm -f ~/.ansible/collections/ansible_collections/rubrikinc/cdm/docs/{template.md,create_documentation_block.py,create_documentation_block.py,rubrik_module_template.py,README.md,SUMMARY.md}
+            python collection_dev.py --action update_path --platform circleci
+
       - run:
           name: Execute Ansible Sanity Test
           command: |
-            cd ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
+            cd ~/.ansible/collections/ansible_collections/rubrikinc/cdm
             ~/ansible/bin/ansible-test sanity --skip-test shebang
       - run:
           name: Execute Unit Tests
           command: |
             sudo pip install ansible --progress-bar off
-            cd ~/.ansible/collections
-            ln -s ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/plugins/ plugins
-            ln -s ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm ./ansible_collections/rubrikinc
-            ln -s ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/plugins/module_utils/ ./ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/module_utils
-            python -m unittest discover -s ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/tests/unit
+            pytest ~/.ansible/collections/ansible_collections/rubrikinc/cdm/tests/unit
 
  python-3.8:
     docker:
@@ -156,32 +153,29 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            sudo pip install pylint requests python-dateutil pytz coverage pytest-cov pytest-mock tox pep8 autopep8 rubrik_cdm paramiko PyYAML Jinja2 httplib2 six voluptuous isort lazy-object-proxy wrapt docutils rstcheck pathspec yamllint
+            sudo pip install pylint requests python-dateutil pytz coverage pytest-cov pytest-mock tox pep8 autopep8 rubrik_cdm paramiko PyYAML Jinja2 httplib2 six voluptuous isort lazy-object-proxy wrapt docutils rstcheck pathspec yamllint --progress-bar off
             sudo apt-get install -y man
       - run:
           name: Clone and Setup Ansible Dev Tools
           command: |
             git clone https://github.com/ansible/ansible.git ~/ansible
             source ~/ansible/hacking/env-setup
-            mkdir -p ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
-            cp -a ~/rubrik-modules-for-ansible/rubrikinc/cdm/. ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/rubrik_module_template.py
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/create_documentation_block.py
-            rm ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/docs/quick-start.md
+            mkdir -p ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            chown -R $USER:$USER ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            cp -a ~/rubrik-modules-for-ansible/rubrikinc/cdm/. ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            rm -f ~/.ansible/collections/ansible_collections/rubrikinc/cdm/docs/{template.md,create_documentation_block.py,create_documentation_block.py,rubrik_module_template.py,README.md,SUMMARY.md}
+            python collection_dev.py --action update_path --platform circleci
+
       - run:
           name: Execute Ansible Sanity Test
           command: |
-            cd ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm
-            ~/ansible/bin/ansible-test sanity --skip-test pylint shebang
+            cd ~/.ansible/collections/ansible_collections/rubrikinc/cdm
+            ~/ansible/bin/ansible-test sanity --skip-test shebang
       - run:
           name: Execute Unit Tests
           command: |
             sudo pip install ansible --progress-bar off
-            cd ~/.ansible/collections
-            ln -s ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/plugins/ plugins
-            ln -s ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm ./ansible_collections/rubrikinc
-            ln -s ~/.ansible/collections/ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/plugins/module_utils/ ./ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/module_utils
-            python -m unittest discover -s ansible_collections/rubrik_cdm/cdm/rubrik_cdm/cdm/tests/unit
+            pytest ~/.ansible/collections/ansible_collections/rubrikinc/cdm/tests/unit
 
 workflows:
   version: 2
@@ -192,3 +186,5 @@ workflows:
       - python-3.6
       - python-3.7
       #- python-3.8
+
+

--- a/collection_dev.py
+++ b/collection_dev.py
@@ -5,11 +5,16 @@ import os
 import argparse
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-a', '--action', choices=['build', 'test'], required=True, help='Specify which action (build or test) you wish to use.')
+parser.add_argument('-a', '--action', choices=['build', 'update_path'], required=True, help='Specify which action (build or test) you wish to use.')
+parser.add_argument('-p', '--platform', choices=['vscode', 'circleci'], default="vscode", required=False, help='The platform you wish to run the script against.')
+
 arguments = parser.parse_args()
 
 collections_path = "from ansible_collections.rubrikinc.cdm.plugins.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec"
 standard_path = "from ansible.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec"
+
+
+
 
 if arguments.action == 'build':
     # Create a list of all modules for processing
@@ -40,17 +45,21 @@ if arguments.action == 'build':
             for line in file:
                 print(line.replace(collections_path, standard_path), end='')
 else:
-
     # Create a list of all modules for processing
     modules = []
-    for dir_path, _, file_name in os.walk('/root/.ansible/collections/ansible_collections/rubrikinc/cdm/plugins/modules'):
+
+    if arguments.platform == 'circleci':
+        search_directory = os.walk("/home/circleci/.ansible/collections/ansible_collections/rubrikinc/cdm")
+    else:
+        search_directory = os.walk("/root/.ansible/collections/ansible_collections/rubrikinc/cdm/plugins/modules")
+        print("VS Code")
+    for dir_path, _, file_name in search_directory:
         for file in file_name:
             if '__pycache__' not in dir_path:
                 modules.append(os.path.join(dir_path, file))
-
-    
     # Update import path to support Ansible Collections
     for m in modules:
+        print(m)
         with fileinput.FileInput(m, inplace=True) as file:
             for line in file:
                 print(line.replace(standard_path, collections_path), end='')

--- a/rubrikinc/cdm/plugins/modules/rubrik_configure_smtp_settings.py
+++ b/rubrikinc/cdm/plugins/modules/rubrik_configure_smtp_settings.py
@@ -54,7 +54,7 @@ options:
         - NONE
         - SSL
         - STARTTLS
-    required: True
+    required: False
     default: NONE
     type: str
   timeout:

--- a/rubrikinc/cdm/tests/unit/test_rubrik_assign_physical_host_fileset.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_assign_physical_host_fileset.py
@@ -6,8 +6,7 @@ import unittest
 from unittest.mock import Mock, patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
-from plugins.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec
-import plugins.modules.rubrik_assign_physical_host_fileset as rubrik_assign_physical_host_fileset
+import ansible_collections.rubrikinc.cdm.plugins.modules.rubrik_assign_physical_host_fileset as rubrik_assign_physical_host_fileset
 
 
 def set_module_args(args):

--- a/rubrikinc/cdm/tests/unit/test_rubrik_assign_sla.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_assign_sla.py
@@ -6,8 +6,7 @@ import unittest
 from unittest.mock import Mock, patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
-from plugins.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec
-import plugins.modules.rubrik_assign_sla as rubrik_assign_sla
+import ansible_collections.rubrikinc.cdm.plugins.modules.rubrik_assign_sla as rubrik_assign_sla
 
 
 def set_module_args(args):

--- a/rubrikinc/cdm/tests/unit/test_rubrik_bootstrap.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_bootstrap.py
@@ -314,7 +314,7 @@ class TestRubrikBootstrap(unittest.TestCase):
         self.assertEqual(result.exception.args[0]['failed'], True)
         self.assertEqual(
             result.exception.args[0]['msg'],
-            'Error: Could not resolve addrsss for cluster, or invalid IP/address supplied')
+            'Error: Could not resolve address for cluster, or invalid IP/address supplied')
 
     def test_module_fail_when_required_args_missing(self):
         with self.assertRaises(AnsibleFailJson):

--- a/rubrikinc/cdm/tests/unit/test_rubrik_bootstrap.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_bootstrap.py
@@ -9,8 +9,7 @@ from ansible.module_utils._text import to_bytes
 from urllib.error import HTTPError
 from rubrik_cdm.exceptions import RubrikException, APICallException
 from socket import gaierror
-from plugins.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec
-import plugins.modules.rubrik_bootstrap as rubrik_bootstrap
+import ansible_collections.rubrikinc.cdm.plugins.modules.rubrik_bootstrap as rubrik_bootstrap
 
 
 def set_module_args(args):
@@ -315,7 +314,7 @@ class TestRubrikBootstrap(unittest.TestCase):
         self.assertEqual(result.exception.args[0]['failed'], True)
         self.assertEqual(
             result.exception.args[0]['msg'],
-            'Error: Could not resolve address for cluster, or invalid IP/address supplied')
+            'Error: Could not resolve addrsss for cluster, or invalid IP/address supplied')
 
     def test_module_fail_when_required_args_missing(self):
         with self.assertRaises(AnsibleFailJson):

--- a/rubrikinc/cdm/tests/unit/test_rubrik_cluster_version.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_cluster_version.py
@@ -6,8 +6,7 @@ import unittest
 from unittest.mock import Mock, patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
-from plugins.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec
-import plugins.modules.rubrik_cluster_version as rubrik_cluster_version
+import ansible_collections.rubrikinc.cdm.plugins.modules.rubrik_cluster_version as rubrik_cluster_version
 
 
 def set_module_args(args):

--- a/rubrikinc/cdm/tests/unit/test_rubrik_dns_servers.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_dns_servers.py
@@ -6,8 +6,7 @@ import unittest
 from unittest.mock import Mock, patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
-from plugins.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec
-import plugins.modules.rubrik_dns_servers as rubrik_dns_servers
+import ansible_collections.rubrikinc.cdm.plugins.modules.rubrik_dns_servers as rubrik_dns_servers
 
 
 def set_module_args(args):

--- a/rubrikinc/cdm/tests/unit/test_rubrik_end_user_authorization.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_end_user_authorization.py
@@ -6,8 +6,7 @@ import unittest
 from unittest.mock import Mock, patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
-from plugins.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec
-import plugins.modules.rubrik_end_user_authorization as rubrik_end_user_authorization
+import ansible_collections.rubrikinc.cdm.plugins.modules.rubrik_end_user_authorization as rubrik_end_user_authorization
 
 
 def set_module_args(args):

--- a/rubrikinc/cdm/tests/unit/test_rubrik_job_status.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_job_status.py
@@ -7,8 +7,7 @@ from unittest.mock import Mock, patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
 from rubrik_cdm.exceptions import RubrikException, APICallException
-from plugins.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec
-import plugins.modules.rubrik_job_status as rubrik_job_status
+import ansible_collections.rubrikinc.cdm.plugins.modules.rubrik_job_status as rubrik_job_status
 
 
 def set_module_args(args):

--- a/rubrikinc/cdm/tests/unit/test_rubrik_managed_volume.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_managed_volume.py
@@ -6,8 +6,7 @@ import unittest
 from unittest.mock import Mock, patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
-from plugins.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec
-import plugins.modules.rubrik_managed_volume as rubrik_managed_volume
+import ansible_collections.rubrikinc.cdm.plugins.modules.rubrik_managed_volume as rubrik_managed_volume
 
 
 def set_module_args(args):

--- a/rubrikinc/cdm/tests/unit/test_rubrik_nas_fileset.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_nas_fileset.py
@@ -6,8 +6,7 @@ import unittest
 from unittest.mock import Mock, patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
-from plugins.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec
-import plugins.modules.rubrik_nas_fileset as rubrik_nas_fileset
+import ansible_collections.rubrikinc.cdm.plugins.modules.rubrik_nas_fileset as rubrik_nas_fileset
 
 
 def set_module_args(args):

--- a/rubrikinc/cdm/tests/unit/test_rubrik_on_demand_snapshot.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_on_demand_snapshot.py
@@ -6,8 +6,7 @@ import unittest
 from unittest.mock import Mock, patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
-from plugins.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec
-import plugins.modules.rubrik_on_demand_snapshot as rubrik_on_demand_snapshot
+import ansible_collections.rubrikinc.cdm.plugins.modules.rubrik_on_demand_snapshot as rubrik_on_demand_snapshot
 
 
 def set_module_args(args):

--- a/rubrikinc/cdm/tests/unit/test_rubrik_physical_fileset.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_physical_fileset.py
@@ -6,8 +6,7 @@ import unittest
 from unittest.mock import Mock, patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
-from plugins.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec
-import plugins.modules.rubrik_physical_fileset as rubrik_physical_fileset
+import ansible_collections.rubrikinc.cdm.plugins.modules.rubrik_physical_fileset as rubrik_physical_fileset
 
 
 def set_module_args(args):

--- a/rubrikinc/cdm/tests/unit/test_rubrik_physical_host.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_physical_host.py
@@ -6,8 +6,7 @@ import unittest
 from unittest.mock import Mock, patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
-from plugins.module_utils.rubrik_cdm import credentials, load_provider_variables, rubrik_argument_spec
-import plugins.modules.rubrik_physical_host as rubrik_physical_host
+import ansible_collections.rubrikinc.cdm.plugins.modules.rubrik_physical_host as rubrik_physical_host
 
 
 def set_module_args(args):


### PR DESCRIPTION
# Description

This PR updates the CircleCI testing for the Ansible Collections format.

- Update and simplify the CircleCI config for the correct Ansible Collection locations
- Fix minor sanity checks detected
- Update import path on unit test files
- Update `collection_dev.py` to include support for the CircleCI platform

Note -- there is one Bootstrap unit test failing that will be fixed in a separate PR.

## How Has This Been Tested?

* locally using the CircleCI CLI

