### PR TITLE
Add SQL support to On-Demand Snapshot

### DIFF
--- a/rubrikinc/cdm/docs/rubrik_on_demand_snapshot.md
+++ b/rubrikinc/cdm/docs/rubrik_on_demand_snapshot.md
@@ -35,14 +35,16 @@ Take an on-demand snapshot of a Rubrik object.
 
 ## Module Specific
 
-| Name        | Description                                                                                                                   | Default | Type   | Choices                    | Mandatory | Aliases |
-|-------------|-------------------------------------------------------------------------------------------------------------------------------|---------|--------|----------------------------|-----------|---------|
-| fileset     | The name of the Fileset you wish to backup. Only required when taking a on-demand snapshot of a physical host.                | None    | string |                            |           |         |
-| host_os     | The operating system for the physical host. Only required when taking a on-demand snapshot of a physical host.                | None    | string | None, Linux, Windows       |           |         |
-| object_name | The name of the Rubrik object to take a on-demand snapshot of.                                                                | vmware  | string | vmware, physical_host, ahv | true      |         |
-| object_type | The Rubrik object type you want to backup.                                                                                    |         |        |                            |           |         |
-| sla_name    | The SLA Domain name you want to assign the on-demand snapshot to. By default, the currently assigned SLA Domain will be used. | current |        |                            |           |         |
-| timeout     | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.                  | 30      | int    |                            |           |         |
+| Name         | Description                                                                                                                   | Default | Type   | Choices                              | Mandatory | Aliases |
+|--------------|-------------------------------------------------------------------------------------------------------------------------------|---------|--------|--------------------------------------|-----------|---------|
+| fileset      | The name of the Fileset you wish to backup. Only required when taking a on-demand snapshot of a physical host.                | None    | string |                                      |           |         |
+| host_os      | The operating system for the physical host. Only required when taking a on-demand snapshot of a physical host.                | None    | string | None, Linux, Windows                 |           |         |
+| object_name  | The name of the Rubrik object to take a on-demand snapshot of.                                                                |         | string |                                      | true      |         |
+| object_type  | The Rubrik object type you want to backup.                                                                                    | vmware  |        | vmware, physical_host, ahv, mssql_db |           |         |
+| sla_name     | The SLA Domain name you want to assign the on-demand snapshot to. By default, the currently assigned SLA Domain will be used. | current |        |                                      |           |         |
+| sql_host     | The name of the SQL Host hosting the specified database. Only required when taking a on-demand snapshot of a MSSQL DB.        | None    | string |                                      |           |         |
+| sql_instance | The name of the SQL Instance hosting the specified database. Only required when taking a on-demand snapshot of a MSSQL DB.    | None    | string |                                      |           |         |
+| timeout      | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.                  | 30      | int    |                                      |           |         |
 
 # Return Values
 

--- a/rubrikinc/cdm/docs/rubrik_sql_live_unmount.md
+++ b/rubrikinc/cdm/docs/rubrik_sql_live_unmount.md
@@ -6,11 +6,10 @@ Delete a Microsoft SQL Live Mount from the Rubrik cluster.
 # Example
 
 ```yaml
-- rubrik_sql_live_mount:
+- rubrik_sql_live_unmount:
     mounted_db_name: 'AdventureWorksClone'
     sql_instance: 'MSSQLSERVER'
     sql_host: 'sql.rubrikdemo.com'
-    force: false
 ```
 
 # Arugments
@@ -30,16 +29,16 @@ Delete a Microsoft SQL Live Mount from the Rubrik cluster.
 
 ## Module Specific
 
-| Name                   | Description                                                                                                                                                         | Default | Type | Choices | Mandatory | Aliases |
-|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|------|---------|-----------|---------|
-| mounted_db_name        | The name of the Live Mounted database to be unmounted.    |         | str  |         | true      |         |
-| sql_instance           | The SQL instance name with the database you wish to Live Mount.                               | None | str  |         |true|         |
-| sql_host               | The name of the MSSQL host running the Live Mounted database to be unmounted.  | None   | str |         |true|         |
-| force             | Remove all data within the Rubrik cluster related to the Live Mount, even if the SQL Server database cannot be contacted.  | false    | bool |        | false |         |
-| timeout                | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. | 30      | int  |         |false|         |
+| Name            | Description                                                                                                               | Default | Type | Choices | Mandatory | Aliases |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------|---------|------|---------|-----------|---------|
+| mounted_db_name | The name of the Live Mounted database to be unmounted.                                                                    |         | str  |         | true      |         |
+| sql_instance    | The SQL instance name with the database you wish to Live Mount.                                                           | None    | str  |         | true      |         |
+| sql_host        | The name of the MSSQL host running the Live Mounted database to be unmounted.                                             | None    | str  |         | true      |         |
+| force           | Remove all data within the Rubrik cluster related to the Live Mount, even if the SQL Server database cannot be contacted. | false   | bool |         | false     |         |
+| timeout         | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.              | 30      | int  |         | false     |         |
 
 # Return Values
 
-| Name     | Description                                                                | Returned | Type | Aliases |
-|----------|----------------------------------------------------------------------------|----------|------|---------|
-| response | The full response of `DELETE /mssql/db/mount/{id}?force={bool}`.           | success  | dict |         |
+| Name     | Description                                                      | Returned | Type | Aliases |
+|----------|------------------------------------------------------------------|----------|------|---------|
+| response | The full response of `DELETE /mssql/db/mount/{id}?force={bool}`. | success  | dict |         |

--- a/rubrikinc/cdm/plugins/modules/rubrik_assign_physical_host_fileset.py
+++ b/rubrikinc/cdm/plugins/modules/rubrik_assign_physical_host_fileset.py
@@ -167,7 +167,7 @@ def main():
         ]
     ]
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+    module = AnsibleModule(argument_spec=argument_spec, required_together=required_together, supports_check_mode=False)
 
     ansible = module.params
 

--- a/rubrikinc/cdm/tests/unit/test_rubrik_on_demand_snapshot.py
+++ b/rubrikinc/cdm/tests/unit/test_rubrik_on_demand_snapshot.py
@@ -668,7 +668,7 @@ class TestRubrikOnDemandSnapshot(unittest.TestCase):
             rubrik_on_demand_snapshot.main()
 
         self.assertEqual(result.exception.args[0]['failed'], True)
-        self.assertEqual(result.exception.args[0]['msg'], "value of object_type must be one of: vmware, physical_host, ahv, got: foo")
+        self.assertEqual(result.exception.args[0]['msg'], "value of object_type must be one of: vmware, physical_host, ahv, mssql_db, got: foo")
 
     def test_module_fail_with_incorrect_host_os(self):
         set_module_args({


### PR DESCRIPTION
# Description

 - Add SQL support to the On-Demand Snapshot Module
- Honor the "required_together" functionality in `rubrik_assign_physical_host_fileset`

## Related Issue

n/a

## Motivation and Context

POC request

## How Has This Been Tested?

```
PLAY [localhost] ************************************************************************************************************************************

TASK [SQL On-Demand Snapshot] ***********************************************************************************************************************
changed: [localhost] => {"changed": true, "job_status_url": "https://amer2-rbk01.rubrikdemo.com/api/v1/mssql/request/MSSQL_DB_BACKUP_4055de1e-f005-4548-9a37-ce91121648d3_ab3d1c23-fa32-47a4-b95f-af49a7c3c9a1:::0", "response": {"id": "MSSQL_DB_BACKUP_4055de1e-f005-4548-9a37-ce91121648d3_ab3d1c23-fa32-47a4-b95f-af49a7c3c9a1:::0", "links": [{"href": "https://amer2-rbk01.rubrikdemo.com/api/v1/mssql/request/MSSQL_DB_BACKUP_4055de1e-f005-4548-9a37-ce91121648d3_ab3d1c23-fa32-47a4-b95f-af49a7c3c9a1:::0", "rel": "self"}], "progress": 0.0, "startTime": "2020-01-19T23:25:13.091Z", "status": "QUEUED"}}

PLAY RECAP ******************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
